### PR TITLE
Pass potential api response data to PostmenException.

### DIFF
--- a/src/Postmen/Postmen.php
+++ b/src/Postmen/Postmen.php
@@ -174,8 +174,8 @@ class Postmen
 		}
 	}
 
-	public function handleError($err_message, $err_code, $err_retryable, $err_details, $parameters) {
-		$error = new PostmenException($err_message, $err_code, $err_retryable, $err_details);
+	public function handleError($err_message, $err_code, $err_retryable, $err_details, $parameters, $response_data = null) {
+		$error = new PostmenException($err_message, $err_code, $err_retryable, $err_details, null, $response_data);
 		if ($parameters['safe']) {
 			$this->_error = $error;
 		} else {
@@ -185,6 +185,11 @@ class Postmen
 	}
 
 	public function handle($parsed, $parameters) {
+		$response_data = $parsed->data;
+		if ($parameters['array']) {
+			$parsed_array = json_decode(json_encode($parsed), true);
+			$response_data = $parsed_array['data'];
+		}
 		if ($parsed->meta->code != 200) {
 			$err_code = 0; 
 			$err_message = 'Postmen server side error occured';
@@ -217,15 +222,9 @@ class Postmen
 					return $retried;
 				}
 			}
-			return $this->handleError($err_message, $err_code, $err_retryable, $err_details, $parameters);
-		} else {
-			if ($parameters['array']) {
-				$parsed_array = json_decode(json_encode($parsed), true);
-				return $parsed_array['data'];
-			} else {
-				return $parsed->data;
-			}
+			return $this->handleError($err_message, $err_code, $err_retryable, $err_details, $parameters, $response_data);
 		}
+		return $response_data;
 	}
 
 	/** takes an associative array $config as argument

--- a/src/Postmen/PostmenException.php
+++ b/src/Postmen/PostmenException.php
@@ -13,10 +13,18 @@ class PostmenException extends Exception
 {
 	private $retryable;
 	private $details;
-	
-	public function __construct($message, $code, $retryable, $details, Exception $previous = null) {
+
+	/**
+	 * @var \stdClass|array|null If the error happened during running an api request and the api responded, then this
+	 *  is the related response. Depending on whether the requests was done with "array: true/false" parameter, the response
+	 *  is either a \stdClass object or an array.
+	 */
+	private $response_data;
+
+	public function __construct($message, $code, $retryable, $details, Exception $previous = null, $response_data = null) {
 		$this->retryable = $retryable;
 		$this->details = $details;
+		$this->response_data = $response_data;
 		parent::__construct($message, $code, $previous);
 	}
 
@@ -26,6 +34,10 @@ class PostmenException extends Exception
 
 	public function getDetails() {
 		return $this->details;
+	}
+
+	public function getResponseData() {
+		return $this->response_data;
 	}
 
 }


### PR DESCRIPTION
This is needed in case an api call to the /rates endpoint returns error details in the response data itself, rather than in the "meta" hashmap. This is usually the case for the 4713 error code.